### PR TITLE
[codex] Add mutation audit logging

### DIFF
--- a/Sources/Cider/Database/CiderSchema.swift
+++ b/Sources/Cider/Database/CiderSchema.swift
@@ -222,6 +222,20 @@ enum CiderSchema {
         );
         """
 
+    static let createMutationAudit = """
+        CREATE TABLE IF NOT EXISTS mutation_audit (
+            id           TEXT PRIMARY KEY,
+            occurred_at  REAL NOT NULL,
+            item_type    TEXT NOT NULL,
+            item_id      TEXT NOT NULL,
+            action       TEXT NOT NULL,
+            source       TEXT NOT NULL,
+            before_state TEXT,
+            after_state  TEXT,
+            metadata     TEXT
+        );
+        """
+
     // MARK: - Indexes
 
     static let createIndexes: [String] = [
@@ -237,6 +251,8 @@ enum CiderSchema {
         "CREATE INDEX IF NOT EXISTS idx_bookmarks_enrich  ON bookmarks(enrichment_status);",
         "CREATE INDEX IF NOT EXISTS idx_todos_completed   ON todos(is_completed);",
         "CREATE INDEX IF NOT EXISTS idx_events_start      ON events(start_at);",
+        "CREATE INDEX IF NOT EXISTS idx_mutation_audit_time ON mutation_audit(occurred_at);",
+        "CREATE INDEX IF NOT EXISTS idx_mutation_audit_item ON mutation_audit(item_type, item_id, occurred_at);",
     ]
 
     // MARK: - All Tables in Dependency Order
@@ -259,6 +275,7 @@ enum CiderSchema {
         createItemTags,
         createItemLinks,
         createTrash,
+        createMutationAudit,
         createSchemaMigrations,
     ]
 }

--- a/Sources/Cider/Database/DatabaseMigrations.swift
+++ b/Sources/Cider/Database/DatabaseMigrations.swift
@@ -10,7 +10,7 @@ enum DatabaseMigrations {
 
     /// Highest schema version this build knows how to run against.
     /// Bump together with any new `migrateToVN` function.
-    static let latestVersion: Int = 5
+    static let latestVersion: Int = 6
 
     /// Run all pending migrations on the given database connection.
     /// Creates the schema_version table if it does not exist.
@@ -47,7 +47,27 @@ enum DatabaseMigrations {
         }
         if currentVersion < 5 {
             try migrateToV5(db)
+            currentVersion = try readVersion(db)
         }
+        if currentVersion < 6 {
+            try migrateToV6(db)
+        }
+    }
+
+    // MARK: - V5 -> V6: mutation audit log
+
+    private static func migrateToV6(_ db: OpaquePointer) throws {
+        logger.info("Migrating to schema version 6...")
+
+        try withTransaction(db) {
+            try runOnDB(db, CiderSchema.createMutationAudit)
+            try runOnDB(db, "CREATE INDEX IF NOT EXISTS idx_mutation_audit_time ON mutation_audit(occurred_at);")
+            try runOnDB(db, "CREATE INDEX IF NOT EXISTS idx_mutation_audit_item ON mutation_audit(item_type, item_id, occurred_at);")
+            try runOnDB(db, "DELETE FROM schema_version;")
+            try runOnDB(db, "INSERT INTO schema_version (version) VALUES (6);")
+        }
+
+        logger.info("Migration to v6 complete")
     }
 
     // MARK: - V4 -> V5: Note summaries move into SQLite

--- a/Sources/Cider/Services/AI/AIAssistantTools.swift
+++ b/Sources/Cider/Services/AI/AIAssistantTools.swift
@@ -654,7 +654,7 @@ struct ApplyTagTool: Tool {
         var tagName: String
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let query = arguments.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         let tagName = arguments.tagName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !tagName.isEmpty else { return "Tag name cannot be empty." }
@@ -687,7 +687,7 @@ struct ApplyTagTool: Tool {
             return "No untagged items found matching \"\(query)\"."
         }
         return "Tagged \(tagged.count) item(s) with \"\(label.name)\":\n" + tagged.joined(separator: "\n")
-    } }
+    } } }
 }
 
 // MARK: - Remove Tag Tool
@@ -706,7 +706,7 @@ struct RemoveTagTool: Tool {
         var tagName: String
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let query = arguments.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         let tagName = arguments.tagName.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -740,7 +740,7 @@ struct RemoveTagTool: Tool {
             return "No items matching \"\(query)\" have the tag \"\(label.name)\"."
         }
         return "Removed tag \"\(label.name)\" from \(untagged.count) item(s):\n" + untagged.joined(separator: "\n")
-    } }
+    } } }
 }
 
 // MARK: - Rename Bookmark Tool
@@ -759,7 +759,7 @@ struct RenameBookmarkTool: Tool {
         var newTitle: String
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let query = arguments.currentTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let newTitle = arguments.newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !newTitle.isEmpty else { return "New title cannot be empty." }
@@ -786,7 +786,7 @@ struct RenameBookmarkTool: Tool {
             labelIDs: bookmark.labelIDs
         )
         return "Renamed \"\(oldTitle)\" → \"\(newTitle)\"."
-    } }
+    } } }
 }
 
 // MARK: - Find Similar Tool
@@ -857,7 +857,7 @@ struct CreateNoteTool: Tool {
         var folderName: String?
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let title = arguments.title.trimmingCharacters(in: .whitespacesAndNewlines)
         let content = arguments.content.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -880,7 +880,7 @@ struct CreateNoteTool: Tool {
         }
 
         return "Created note \"\(note.title)\"."
-    } }
+    } } }
 }
 
 // MARK: - Summarize Text Tool
@@ -1242,7 +1242,7 @@ struct CreateReminderTool: Tool {
         var details: String?
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let title = arguments.title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !title.isEmpty else { return "Reminder title cannot be empty." }
 
@@ -1302,7 +1302,7 @@ struct CreateReminderTool: Tool {
             .map { $0 == 0 ? "at time" : "\($0) min before" }
             .joined(separator: ", ")
         return "Created reminder: \"\(title)\" on \(arguments.date)\(recurring). Reminders: \(remindDesc)."
-    } }
+    } } }
 }
 
 // MARK: - Cancel Reminder Tool
@@ -1324,7 +1324,7 @@ struct CancelReminderTool: Tool {
         var deleteEntirely: Bool?
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let query = arguments.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty else { return "Reminder title cannot be empty." }
 
@@ -1351,5 +1351,5 @@ struct CancelReminderTool: Tool {
         _ = storage.updateDateCard(card)
         DateCardNotificationService.shared.cancelNotification(for: card.id)
         return "Disabled reminders for \"\(card.title)\". The event still exists but won't send notifications."
-    } }
+    } } }
 }

--- a/Sources/Cider/Services/AI/AIAssistantTools.swift
+++ b/Sources/Cider/Services/AI/AIAssistantTools.swift
@@ -18,7 +18,7 @@ struct CountItemsTool: Tool {
         var itemType: String
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let type = arguments.itemType.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
 
         switch type {
@@ -73,7 +73,7 @@ struct CountItemsTool: Tool {
         default:
             return ("Unknown item type '\(type)'. Valid types: bookmarks, notes, events, todos, contacts, folders, tags, clipboard, all.")
         }
-    } }
+    } } }
 }
 
 // MARK: - Search Items Tool
@@ -96,7 +96,7 @@ struct SearchItemsTool: Tool {
         var itemType: String?
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let query = arguments.query.lowercased()
         var results: [String] = []
 
@@ -182,7 +182,7 @@ struct SearchItemsTool: Tool {
             return ("No items found matching \"\(arguments.query)\".")
         }
         return ("Found \(results.count) results:\n" + results.joined(separator: "\n"))
-    } }
+    } } }
 }
 
 // MARK: - List Folders Tool
@@ -198,7 +198,7 @@ struct ListFoldersTool: Tool {
     @Generable
     struct Arguments {}
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let folders = VaultFolderService.shared.folders
         if folders.isEmpty {
             return ("No folders exist yet.")
@@ -225,7 +225,7 @@ struct ListFoldersTool: Tool {
             lines.append("\(prefix)📁 \(folder.name) (\(total) items: \(bCount) bookmarks, \(nCount) notes, \(eCount) events, \(tCount) todos, \(cCount) contacts)")
         }
         return ("Folders:\n" + lines.joined(separator: "\n"))
-    } }
+    } } }
 }
 
 // MARK: - List Tags Tool
@@ -238,7 +238,7 @@ struct ListTagsTool: Tool {
     @Generable
     struct Arguments {}
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let labels = CardLabelStorage.shared.labels
         if labels.isEmpty {
             return ("No tags/labels exist yet.")
@@ -250,7 +250,7 @@ struct ListTagsTool: Tool {
             lines.append("🏷 \(label.name) (\(count) items)")
         }
         return ("Tags:\n" + lines.joined(separator: "\n"))
-    } }
+    } } }
 }
 
 // MARK: - Get Recent Items Tool
@@ -918,7 +918,7 @@ struct SummarizeTextTool: Tool {
         }
 
         if arguments.saveAsNote == true {
-            return await MainActor.run {
+            return await MainActor.run { MutationAuditContext.withSource(.agent) {
                 let title = arguments.noteTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "Summary"
                 var note = NotesStorage.shared.createNew(initialContent: summary)
                 note.title = title
@@ -933,7 +933,7 @@ struct SummarizeTextTool: Tool {
                     return "Summary saved as note \"\(title)\" in folder \"\(folder.name)\":\n\n\(summary)"
                 }
                 return "Summary saved as note \"\(title)\":\n\n\(summary)"
-            }
+            } }
         }
 
         return "Summary:\n\n\(summary)"
@@ -964,7 +964,7 @@ struct AddBookmarkTool: Tool {
         var tagName: String?
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let urlString = arguments.url.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !urlString.isEmpty else { return "URL cannot be empty." }
 
@@ -994,7 +994,7 @@ struct AddBookmarkTool: Tool {
         }
 
         return actions.joined(separator: ", ") + "."
-    } }
+    } } }
 }
 
 // MARK: - Get Current Item Tool
@@ -1011,7 +1011,7 @@ struct GetCurrentItemTool: Tool {
     @Generable
     struct Arguments {}
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let context = AIAssistantViewModel.shared.context
 
         if let bookmark = context.currentBookmark {
@@ -1063,7 +1063,7 @@ struct GetCurrentItemTool: Tool {
         }
 
         return "The user is not currently viewing any specific item. They may be on the home screen or library view."
-    } }
+    } } }
 }
 
 // MARK: - Delete Item Tool
@@ -1085,7 +1085,7 @@ struct DeleteItemTool: Tool {
         var itemType: String
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let query = arguments.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         let type = arguments.itemType.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -1122,7 +1122,7 @@ struct DeleteItemTool: Tool {
         }
 
         return "Unknown item type '\(type)'. Use 'bookmark' or 'note'."
-    } }
+    } } }
 }
 
 // MARK: - Rename Folder Tool
@@ -1141,7 +1141,7 @@ struct RenameFolderTool: Tool {
         var newName: String
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let current = arguments.currentName.trimmingCharacters(in: .whitespacesAndNewlines)
         let newName = arguments.newName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !newName.isEmpty else { return "New name cannot be empty." }
@@ -1158,7 +1158,7 @@ struct RenameFolderTool: Tool {
             return "Renamed folder \"\(current)\" → \"\(newName)\"."
         }
         return "Failed to rename folder \"\(current)\". The name \"\(newName)\" may already be taken."
-    } }
+    } } }
 }
 
 // MARK: - Unfile Items Tool
@@ -1177,7 +1177,7 @@ struct UnfileItemsTool: Tool {
         var searchQuery: String
     }
 
-    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run {
+    nonisolated func call(arguments: Arguments) async throws -> String { await MainActor.run { MutationAuditContext.withSource(.agent) {
         let query = arguments.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         var unfiled: [String] = []
 
@@ -1201,7 +1201,7 @@ struct UnfileItemsTool: Tool {
             return "No filed items found matching \"\(query)\"."
         }
         return "Unfiled \(unfiled.count) item(s) (moved to root):\n" + unfiled.joined(separator: "\n")
-    } }
+    } } }
 }
 
 // MARK: - Create Reminder Tool

--- a/Sources/Cider/Services/AI/MLXToolExecutor.swift
+++ b/Sources/Cider/Services/AI/MLXToolExecutor.swift
@@ -561,6 +561,7 @@ enum MLXToolExecutor {
     }
 
     private static func applyTag(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let query = string("searchQuery", from: args)
         let tagName = string("tagName", from: args)
         guard !tagName.isEmpty else { return "Tag name cannot be empty." }
@@ -585,9 +586,11 @@ enum MLXToolExecutor {
 
         if tagged.isEmpty { return "No untagged items found matching \"\(query)\"." }
         return "Tagged \(tagged.count) item(s) with \"\(label.name)\":\n" + tagged.joined(separator: "\n")
+        }
     }
 
     private static func removeTag(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let query = string("searchQuery", from: args)
         let tagName = string("tagName", from: args)
 
@@ -616,6 +619,7 @@ enum MLXToolExecutor {
 
         if untagged.isEmpty { return "No items matching \"\(query)\" have the tag \"\(label.name)\"." }
         return "Removed tag \"\(label.name)\" from \(untagged.count) item(s):\n" + untagged.joined(separator: "\n")
+        }
     }
 
     private static func renameBookmark(_ args: [String: Any]) -> String {

--- a/Sources/Cider/Services/AI/MLXToolExecutor.swift
+++ b/Sources/Cider/Services/AI/MLXToolExecutor.swift
@@ -507,6 +507,7 @@ enum MLXToolExecutor {
     // MARK: - Mutating tools
 
     private static func createFolder(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let name = string("folderName", from: args)
         guard !name.isEmpty else { return "Folder name cannot be empty." }
 
@@ -525,9 +526,11 @@ enum MLXToolExecutor {
         }
         let location = parentID != nil ? "inside \"\(optString("parentFolderName", from: args) ?? "")\"" : "at root level"
         return "Created folder \"\(folder.name)\" \(location)."
+        }
     }
 
     private static func moveToFolder(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let query = string("searchQuery", from: args)
         let folderName = string("folderName", from: args)
 
@@ -554,6 +557,7 @@ enum MLXToolExecutor {
 
         if moved.isEmpty { return "No items found matching \"\(query)\" to move." }
         return "Moved \(moved.count) item(s) to \"\(folder.name)\":\n" + moved.joined(separator: "\n")
+        }
     }
 
     private static func applyTag(_ args: [String: Any]) -> String {
@@ -615,6 +619,7 @@ enum MLXToolExecutor {
     }
 
     private static func renameBookmark(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let query = string("currentTitle", from: args)
         let newTitle = string("newTitle", from: args)
         guard !newTitle.isEmpty else { return "New title cannot be empty." }
@@ -632,9 +637,11 @@ enum MLXToolExecutor {
             tags: bookmark.tags, labelIDs: bookmark.labelIDs
         )
         return "Renamed \"\(oldTitle)\" to \"\(newTitle)\"."
+        }
     }
 
     private static func createNote(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let title = string("title", from: args)
         let content = string("content", from: args)
 
@@ -652,9 +659,11 @@ enum MLXToolExecutor {
             return "Created note \"\(note.title)\" (folder \"\(folderName)\" not found — saved to root)."
         }
         return "Created note \"\(note.title)\"."
+        }
     }
 
     private static func addBookmark(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let urlString = string("url", from: args)
         guard !urlString.isEmpty else { return "URL cannot be empty." }
 
@@ -679,9 +688,11 @@ enum MLXToolExecutor {
         }
 
         return actions.joined(separator: ", ") + "."
+        }
     }
 
     private static func deleteItem(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let query = string("searchQuery", from: args)
         let type = string("itemType", from: args).lowercased()
 
@@ -710,9 +721,11 @@ enum MLXToolExecutor {
         }
 
         return "Unknown item type '\(type)'. Use 'bookmark' or 'note'."
+        }
     }
 
     private static func renameFolder(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let current = string("currentName", from: args)
         let newName = string("newName", from: args)
         guard !newName.isEmpty else { return "New name cannot be empty." }
@@ -726,9 +739,11 @@ enum MLXToolExecutor {
         let success = VaultFolderService.shared.renameFolder(folder.id, to: newName)
         if success { return "Renamed folder \"\(current)\" to \"\(newName)\"." }
         return "Failed to rename folder \"\(current)\". The name \"\(newName)\" may already be taken."
+        }
     }
 
     private static func unfileItems(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let query = string("searchQuery", from: args)
         var unfiled: [String] = []
 
@@ -747,11 +762,13 @@ enum MLXToolExecutor {
 
         if unfiled.isEmpty { return "No filed items found matching \"\(query)\"." }
         return "Unfiled \(unfiled.count) item(s) (moved to root):\n" + unfiled.joined(separator: "\n")
+        }
     }
 
     // MARK: - Create Reminder
 
     private static func createReminder(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let title = string("title", from: args)
         guard !title.isEmpty else {
             return "Reminder title is required."
@@ -807,11 +824,13 @@ enum MLXToolExecutor {
 
         let recurring = card.recurrenceRule != nil ? " (recurring \(card.recurrenceRule!.frequency.rawValue))" : ""
         return "Created reminder: \"\(title)\" on \(dateStr)\(recurring)."
+        }
     }
 
     // MARK: - Cancel Reminder
 
     private static func cancelReminder(_ args: [String: Any]) -> String {
+        MutationAuditContext.withSource(.agent) {
         let query = string("title", from: args).lowercased()
         guard !query.isEmpty else {
             return "Reminder title is required."
@@ -841,5 +860,6 @@ enum MLXToolExecutor {
         _ = storage.updateDateCard(card)
         DateCardNotificationService.shared.cancelNotification(for: card.id)
         return "Disabled reminders for \"\(card.title)\". The event still exists but won't send notifications."
+        }
     }
 }

--- a/Sources/Cider/Services/ContactStorage.swift
+++ b/Sources/Cider/Services/ContactStorage.swift
@@ -213,12 +213,20 @@ final class ContactStorage: ObservableObject {
         contacts.append(contact)
         sortContacts()
         persistContactToDatabase(contact)
+        MutationAuditService.shared.record(
+            action: "create",
+            itemType: "contact",
+            itemID: contact.id,
+            after: MutationAuditSnapshots.contact(contact)
+        )
         return contact
     }
 
     @discardableResult
     func updateContact(_ updated: ContactCard) -> Bool {
         guard let idx = contacts.firstIndex(where: { $0.id == updated.id }) else { return false }
+        let beforeContact = contacts[idx]
+        let before = MutationAuditSnapshots.contact(beforeContact)
         var copy = updated
         copy.updatedAt = Date()
 
@@ -256,12 +264,22 @@ final class ContactStorage: ObservableObject {
         saveIndex()
         sortContacts()
         persistContactToDatabase(copy)
+        if beforeContact.displayName != copy.displayName {
+            MutationAuditService.shared.record(
+                action: "rename",
+                itemType: "contact",
+                itemID: copy.id,
+                before: before,
+                after: MutationAuditSnapshots.contact(copy)
+            )
+        }
         return true
     }
 
     @discardableResult
     func deleteContact(_ id: UUID) -> TrashItem? {
         guard let contact = contacts.first(where: { $0.id == id }) else { return nil }
+        let before = MutationAuditSnapshots.contact(contact)
 
         // Resolve the .vcf file URL so TrashStorage can move it
         let vcfFileURL = resolveFileURL(for: id)
@@ -275,6 +293,13 @@ final class ContactStorage: ObservableObject {
         index.removeValue(forKey: id)
         saveIndex()
         deleteContactFromDatabase(id)
+        MutationAuditService.shared.record(
+            action: "delete",
+            itemType: "contact",
+            itemID: id,
+            before: before,
+            after: MutationAuditSnapshots.trashItem(trashItem)
+        )
         return trashItem
     }
 
@@ -284,6 +309,7 @@ final class ContactStorage: ObservableObject {
         guard contacts[idx].folderID != folderID else { return true }
 
         let contact = contacts[idx]
+        let before = MutationAuditSnapshots.contact(contact)
         guard let entry = index[id] else { return false }
         let filename = entry.filename
 
@@ -315,6 +341,13 @@ final class ContactStorage: ObservableObject {
         index[id] = updatedEntry
         saveIndex()
         persistContactToDatabase(contacts[idx])
+        MutationAuditService.shared.record(
+            action: "reassign_folder",
+            itemType: "contact",
+            itemID: id,
+            before: before,
+            after: MutationAuditSnapshots.contact(contacts[idx])
+        )
         return true
     }
 
@@ -405,6 +438,20 @@ final class ContactStorage: ObservableObject {
         contacts.append(contact)
         sortContacts()
         persistContactToDatabase(contact)
+        MutationAuditService.shared.record(
+            action: "restore",
+            itemType: "contact",
+            itemID: contact.id,
+            before: MutationAuditSnapshots.trashItem(
+                TrashItem(
+                    itemID: contact.id,
+                    itemType: .contact,
+                    title: contact.displayName,
+                    originalFolderID: contact.folderID
+                )
+            ),
+            after: MutationAuditSnapshots.contact(contact)
+        )
     }
 
     // MARK: - Avatar Storage

--- a/Sources/Cider/Services/DateCardStorage.swift
+++ b/Sources/Cider/Services/DateCardStorage.swift
@@ -217,12 +217,20 @@ final class DateCardStorage: ObservableObject {
         dateCards.append(dateCard)
         sortCards()
         persistEventToDatabase(dateCard)
+        MutationAuditService.shared.record(
+            action: "create",
+            itemType: "dateCard",
+            itemID: dateCard.id,
+            after: MutationAuditSnapshots.dateCard(dateCard)
+        )
         return dateCard
     }
 
     @discardableResult
     func updateDateCard(_ updated: DateCard) -> Bool {
         guard let idx = dateCards.firstIndex(where: { $0.id == updated.id }) else { return false }
+        let beforeCard = dateCards[idx]
+        let before = MutationAuditSnapshots.dateCard(beforeCard)
         var copy = updated
         copy.updatedAt = Date()
 
@@ -258,12 +266,41 @@ final class DateCardStorage: ObservableObject {
         saveIndex()
         sortCards()
         persistEventToDatabase(copy)
+        if beforeCard.title != copy.title {
+            MutationAuditService.shared.record(
+                action: "rename",
+                itemType: "dateCard",
+                itemID: copy.id,
+                before: before,
+                after: MutationAuditSnapshots.dateCard(copy)
+            )
+        }
+        let beforeHasReminder = beforeCard.rules.contains { $0.type == .remindBeforeMinutes && $0.isEnabled }
+        let afterHasReminder = copy.rules.contains { $0.type == .remindBeforeMinutes && $0.isEnabled }
+        if !beforeHasReminder && afterHasReminder {
+            MutationAuditService.shared.record(
+                action: "create_reminder",
+                itemType: "dateCard",
+                itemID: copy.id,
+                before: before,
+                after: MutationAuditSnapshots.dateCard(copy)
+            )
+        } else if beforeHasReminder && !afterHasReminder {
+            MutationAuditService.shared.record(
+                action: "cancel_reminder",
+                itemType: "dateCard",
+                itemID: copy.id,
+                before: before,
+                after: MutationAuditSnapshots.dateCard(copy)
+            )
+        }
         return true
     }
 
     @discardableResult
     func deleteDateCard(_ id: UUID) -> TrashItem? {
         guard let dateCard = dateCards.first(where: { $0.id == id }) else { return nil }
+        let before = MutationAuditSnapshots.dateCard(dateCard)
 
         let icsFileURL = resolveFileURL(for: id)
         let trashItem = TrashStorage.shared.trashDateCard(
@@ -276,6 +313,13 @@ final class DateCardStorage: ObservableObject {
         index.removeValue(forKey: id)
         saveIndex()
         deleteEventFromDatabase(id)
+        MutationAuditService.shared.record(
+            action: "delete",
+            itemType: "dateCard",
+            itemID: id,
+            before: before,
+            after: MutationAuditSnapshots.trashItem(trashItem)
+        )
         return trashItem
     }
 
@@ -295,6 +339,7 @@ final class DateCardStorage: ObservableObject {
         guard dateCards[idx].folderID != folderID else { return true }
 
         let dateCard = dateCards[idx]
+        let before = MutationAuditSnapshots.dateCard(dateCard)
         guard let entry = index[id] else { return false }
 
         let oldDirURL = resolveDirectoryURL(folderID: dateCard.folderID)
@@ -323,6 +368,13 @@ final class DateCardStorage: ObservableObject {
         index[id] = updatedEntry
         saveIndex()
         persistEventToDatabase(dateCards[idx])
+        MutationAuditService.shared.record(
+            action: "reassign_folder",
+            itemType: "dateCard",
+            itemID: id,
+            before: before,
+            after: MutationAuditSnapshots.dateCard(dateCards[idx])
+        )
         return true
     }
 
@@ -420,6 +472,20 @@ final class DateCardStorage: ObservableObject {
         dateCards.append(dateCard)
         sortCards()
         persistEventToDatabase(dateCard)
+        MutationAuditService.shared.record(
+            action: "restore",
+            itemType: "dateCard",
+            itemID: dateCard.id,
+            before: MutationAuditSnapshots.trashItem(
+                TrashItem(
+                    itemID: dateCard.id,
+                    itemType: .dateCard,
+                    title: dateCard.title,
+                    originalFolderID: dateCard.folderID
+                )
+            ),
+            after: MutationAuditSnapshots.dateCard(dateCard)
+        )
     }
 
     // MARK: - File I/O

--- a/Sources/Cider/Services/MutationAuditService.swift
+++ b/Sources/Cider/Services/MutationAuditService.swift
@@ -1,0 +1,291 @@
+import Foundation
+import os
+
+enum MutationAuditSource: String, Codable {
+    case ui
+    case cli
+    case agent
+    case migration
+    case cleanup
+}
+
+@MainActor
+enum MutationAuditContext {
+    private static var sourceStack: [MutationAuditSource] = []
+
+    static var currentSource: MutationAuditSource {
+        sourceStack.last ?? .ui
+    }
+
+    static func withSource<T>(
+        _ source: MutationAuditSource,
+        _ body: () throws -> T
+    ) rethrows -> T {
+        sourceStack.append(source)
+        defer { _ = sourceStack.popLast() }
+        return try body()
+    }
+
+    static func withSource<T>(
+        _ source: MutationAuditSource,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        sourceStack.append(source)
+        defer { _ = sourceStack.popLast() }
+        return try await operation()
+    }
+}
+
+struct MutationAuditEntry: Identifiable, Equatable {
+    let id: UUID
+    let occurredAt: Date
+    let itemType: String
+    let itemID: UUID
+    let action: String
+    let source: MutationAuditSource
+    let beforeState: [String: String]
+    let afterState: [String: String]
+    let metadata: [String: String]
+}
+
+@MainActor
+final class MutationAuditService {
+    static let shared = MutationAuditService()
+
+    private let logger = Logger(subsystem: "com.cider.app", category: "MutationAudit")
+    private let database: CiderDatabase?
+
+    private var resolvedDatabase: CiderDatabase? {
+        database ?? (CiderDatabase.shared.isOpen ? CiderDatabase.shared : nil)
+    }
+
+    init(database: CiderDatabase? = nil) {
+        self.database = database
+    }
+
+    func record(
+        action: String,
+        itemType: String,
+        itemID: UUID,
+        before: [String: String]? = nil,
+        after: [String: String]? = nil,
+        metadata: [String: String]? = nil,
+        source: MutationAuditSource? = nil
+    ) {
+        guard let db = resolvedDatabase else { return }
+
+        let entry = MutationAuditEntry(
+            id: UUID(),
+            occurredAt: Date(),
+            itemType: itemType,
+            itemID: itemID,
+            action: action,
+            source: source ?? inferredSource(),
+            beforeState: before ?? [:],
+            afterState: after ?? [:],
+            metadata: metadata ?? [:]
+        )
+
+        do {
+            try db.withTransaction {
+                try self.persist(entry, in: db)
+            }
+        } catch {
+            logger.error("Failed to record mutation audit entry: \(error.localizedDescription)")
+        }
+    }
+
+    func loadEntries(limit: Int? = nil) -> [MutationAuditEntry] {
+        guard let db = resolvedDatabase else { return [] }
+
+        do {
+            let sql: String
+            if let limit, limit > 0 {
+                sql = """
+                    SELECT id, occurred_at, item_type, item_id, action, source, before_state, after_state, metadata
+                    FROM mutation_audit
+                    ORDER BY occurred_at DESC, id DESC
+                    LIMIT \(limit);
+                    """
+            } else {
+                sql = """
+                    SELECT id, occurred_at, item_type, item_id, action, source, before_state, after_state, metadata
+                    FROM mutation_audit
+                    ORDER BY occurred_at DESC, id DESC;
+                    """
+            }
+
+            let stmt = try db.prepare(sql)
+            var entries: [MutationAuditEntry] = []
+            while try stmt.step() {
+                guard
+                    let id = DatabaseHelpers.decodeUUID(stmt.string(at: 0)),
+                    let itemID = DatabaseHelpers.decodeUUID(stmt.string(at: 3)),
+                    let source = MutationAuditSource(rawValue: stmt.string(at: 5))
+                else {
+                    continue
+                }
+
+                entries.append(
+                    MutationAuditEntry(
+                        id: id,
+                        occurredAt: DatabaseHelpers.decodeDate(stmt.double(at: 1)),
+                        itemType: stmt.string(at: 2),
+                        itemID: itemID,
+                        action: stmt.string(at: 4),
+                        source: source,
+                        beforeState: DatabaseHelpers.decodeJSON([String: String].self, from: stmt.optionalString(at: 6)) ?? [:],
+                        afterState: DatabaseHelpers.decodeJSON([String: String].self, from: stmt.optionalString(at: 7)) ?? [:],
+                        metadata: DatabaseHelpers.decodeJSON([String: String].self, from: stmt.optionalString(at: 8)) ?? [:]
+                    )
+                )
+            }
+            return entries
+        } catch {
+            logger.error("Failed to load mutation audit entries: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    private func persist(_ entry: MutationAuditEntry, in db: CiderDatabase) throws {
+        let stmt = try db.prepare("""
+            INSERT INTO mutation_audit (
+                id, occurred_at, item_type, item_id, action, source, before_state, after_state, metadata
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """)
+
+        stmt.bind(DatabaseHelpers.encode(entry.id), at: 1)
+            .bind(DatabaseHelpers.encode(entry.occurredAt), at: 2)
+            .bind(entry.itemType, at: 3)
+            .bind(DatabaseHelpers.encode(entry.itemID), at: 4)
+            .bind(entry.action, at: 5)
+            .bind(entry.source.rawValue, at: 6)
+            .bind(DatabaseHelpers.encodeJSON(entry.beforeState), at: 7)
+            .bind(DatabaseHelpers.encodeJSON(entry.afterState), at: 8)
+            .bind(DatabaseHelpers.encodeJSON(entry.metadata), at: 9)
+        try stmt.step()
+    }
+
+    private func inferredSource() -> MutationAuditSource {
+        let contextualSource = MutationAuditContext.currentSource
+        if contextualSource != .ui {
+            return contextualSource
+        }
+
+        let processName = ProcessInfo.processInfo.processName.lowercased()
+        if processName == "cider-cli" || processName == "cidercli" {
+            return .cli
+        }
+
+        return .ui
+    }
+}
+
+enum MutationAuditSnapshots {
+    static func folder(_ folder: VaultFolder) -> [String: String] {
+        compact([
+            ("name", folder.name),
+            ("relativePath", folder.relativePath),
+            ("parentRelativePath", folder.parentRelativePath),
+            ("icon", folder.icon),
+        ])
+    }
+
+    static func bookmark(_ bookmark: Bookmark) -> [String: String] {
+        compact([
+            ("title", bookmark.title),
+            ("url", bookmark.urlString),
+            ("folderID", bookmark.folderID?.uuidString),
+            ("relativePath", bookmark.relativePath),
+            ("tagCount", String(bookmark.tags.count)),
+            ("labelCount", String(bookmark.labelIDs.count)),
+        ])
+    }
+
+    static func note(_ note: Note) -> [String: String] {
+        compact([
+            ("title", note.title),
+            ("folderID", note.folderID?.uuidString),
+            ("relativePath", note.relativePath),
+            ("tagCount", String(note.tags.count)),
+            ("labelCount", String(note.labelIDs.count)),
+            ("isPinned", boolString(note.isPinned)),
+        ])
+    }
+
+    static func todo(_ todo: TodoCard) -> [String: String] {
+        compact([
+            ("title", todo.title),
+            ("folderID", todo.folderID?.uuidString),
+            ("dueDate", dateString(todo.dueDate)),
+            ("priority", todo.priority?.rawValue),
+            ("isCompleted", boolString(todo.isCompleted)),
+        ])
+    }
+
+    static func dateCard(_ card: DateCard) -> [String: String] {
+        compact([
+            ("title", card.title),
+            ("folderID", card.folderID?.uuidString),
+            ("startAt", dateString(card.startAt)),
+            ("allDay", boolString(card.allDay)),
+            ("isCompleted", boolString(card.isCompleted)),
+            ("reminderOffsets", reminderOffsetsString(card)),
+        ])
+    }
+
+    static func contact(_ contact: ContactCard) -> [String: String] {
+        compact([
+            ("displayName", contact.displayName),
+            ("folderID", contact.folderID?.uuidString),
+            ("email", contact.email),
+            ("phone", contact.phone),
+            ("hasAvatar", boolString(contact.hasAvatar)),
+        ])
+    }
+
+    static func vaultFile(_ file: VaultFile) -> [String: String] {
+        compact([
+            ("filename", file.filename),
+            ("displayTitle", file.displayTitle),
+            ("folderID", file.folderID?.uuidString),
+            ("relativePath", file.relativePath),
+            ("fileType", file.fileType.rawValue),
+        ])
+    }
+
+    static func trashItem(_ item: TrashItem) -> [String: String] {
+        compact([
+            ("trashItemID", item.id.uuidString),
+            ("title", item.title),
+            ("itemType", item.itemType.rawValue),
+            ("originalFolderID", item.originalFolderID?.uuidString),
+            ("deletedAt", dateString(item.deletedAt)),
+        ])
+    }
+
+    private static func compact(_ pairs: [(String, String?)]) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: pairs.compactMap { key, value in
+            value.map { (key, $0) }
+        })
+    }
+
+    private static func dateString(_ date: Date?) -> String? {
+        guard let date else { return nil }
+        return String(date.timeIntervalSince1970)
+    }
+
+    private static func boolString(_ value: Bool) -> String {
+        value ? "true" : "false"
+    }
+
+    private static func reminderOffsetsString(_ card: DateCard) -> String? {
+        let offsets = card.rules
+            .filter { $0.type == .remindBeforeMinutes && $0.isEnabled }
+            .compactMap(\.integerValue)
+            .sorted()
+        guard !offsets.isEmpty else { return nil }
+        return offsets.map(String.init).joined(separator: ",")
+    }
+}

--- a/Sources/Cider/Services/MutationAuditService.swift
+++ b/Sources/Cider/Services/MutationAuditService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-enum MutationAuditSource: String, Codable {
+enum MutationAuditSource: String, Codable, CaseIterable {
     case ui
     case cli
     case agent

--- a/Sources/Cider/Services/NotesStorage.swift
+++ b/Sources/Cider/Services/NotesStorage.swift
@@ -645,6 +645,12 @@ final class NotesStorage: ObservableObject {
         let note = Note(id: uuid, title: title, content: initialContent, createdAt: now, modifiedAt: now, relativePath: inboxRelativePath)
         notes.insert(note, at: 0)
         persistNoteToDatabase(note)
+        MutationAuditService.shared.record(
+            action: "create",
+            itemType: "note",
+            itemID: note.id,
+            after: MutationAuditSnapshots.note(note)
+        )
         return note
     }
 
@@ -728,6 +734,13 @@ final class NotesStorage: ObservableObject {
         )
         notes.insert(note, at: 0)
         persistNoteToDatabase(note)
+        MutationAuditService.shared.record(
+            action: "create",
+            itemType: "note",
+            itemID: note.id,
+            after: MutationAuditSnapshots.note(note),
+            metadata: sourceURL.map { ["sourceURL": $0] }
+        )
         return note
     }
 
@@ -801,6 +814,7 @@ final class NotesStorage: ObservableObject {
     }
 
     func rename(note: Note, to newTitle: String) {
+        let before = MutationAuditSnapshots.note(note)
         let sanitized = newTitle.replacingOccurrences(of: "/", with: "-")
             .replacingOccurrences(of: ":", with: "-")
         guard !sanitized.isEmpty else { return }
@@ -838,6 +852,13 @@ final class NotesStorage: ObservableObject {
                 notes[idx].relativePath = newRelativePath
                 notes[idx].modifiedAt = Date()
                 persistNoteToDatabase(notes[idx])
+                MutationAuditService.shared.record(
+                    action: "rename",
+                    itemType: "note",
+                    itemID: note.id,
+                    before: before,
+                    after: MutationAuditSnapshots.note(notes[idx])
+                )
             }
             SyncService.shared.pushAfterLocalChange()
         } catch {
@@ -873,6 +894,7 @@ final class NotesStorage: ObservableObject {
         guard notes[idx].folderID != folderID else { return true }
 
         let note = notes[idx]
+        let before = MutationAuditSnapshots.note(note)
         let filename = (note.relativePath as NSString).lastPathComponent
         let oldFileURL = noteFileURL(for: note)
 
@@ -931,6 +953,13 @@ final class NotesStorage: ObservableObject {
         }
         saveIndex()
         persistNoteToDatabase(notes[idx])
+        MutationAuditService.shared.record(
+            action: "reassign_folder",
+            itemType: "note",
+            itemID: noteID,
+            before: before,
+            after: MutationAuditSnapshots.note(notes[idx])
+        )
         SyncService.shared.pushAfterLocalChange()
         return true
     }
@@ -1021,6 +1050,7 @@ final class NotesStorage: ObservableObject {
 
     @discardableResult
     func delete(note: Note, trackSync: Bool = true) -> TrashItem {
+        let before = MutationAuditSnapshots.note(note)
         contentCache.removeValue(forKey: note.id)
 
         // For notes in vault/Inbox folders, move the file to Inbox/Notes/ first so trash works correctly
@@ -1068,6 +1098,14 @@ final class NotesStorage: ObservableObject {
                 SyncService.shared.trackNoteDeletion(of: note.id)
             }
         }
+
+        MutationAuditService.shared.record(
+            action: "delete",
+            itemType: "note",
+            itemID: note.id,
+            before: before,
+            after: MutationAuditSnapshots.trashItem(trashItem)
+        )
 
         return trashItem
     }
@@ -1203,8 +1241,10 @@ final class NotesStorage: ObservableObject {
     /// Routes through TrashStorage so the note can be recovered locally.
     /// Does NOT re-report to SyncService to avoid deletion ping-pong.
     func deleteFromSync(_ note: Note) {
-        contentCache.removeValue(forKey: note.id)
-        let _ = delete(note: note, trackSync: false)
+        MutationAuditContext.withSource(.cleanup) {
+            contentCache.removeValue(forKey: note.id)
+            let _ = delete(note: note, trackSync: false)
+        }
     }
 
     func restoreFromTrash(noteID: UUID, filename: String, folderID: UUID?, createdAt: Date) {
@@ -1218,6 +1258,17 @@ final class NotesStorage: ObservableObject {
         // Persist restored note to the database
         if let restoredNote = notes.first(where: { $0.id == noteID }) {
             persistNoteToDatabase(restoredNote)
+            var before: [String: String] = ["trashFilename": filename]
+            if let folderID {
+                before["folderID"] = folderID.uuidString
+            }
+            MutationAuditService.shared.record(
+                action: "restore",
+                itemType: "note",
+                itemID: noteID,
+                before: before,
+                after: MutationAuditSnapshots.note(restoredNote)
+            )
         }
         // Cancel pending sync deletion and push so the note reappears on web
         SyncService.shared.cancelNoteDeletion(of: noteID)

--- a/Sources/Cider/Services/NotesStorage.swift
+++ b/Sources/Cider/Services/NotesStorage.swift
@@ -968,6 +968,7 @@ final class NotesStorage: ObservableObject {
     func assignLabel(_ noteID: UUID, labelID: UUID) -> Bool {
         guard let idx = notes.firstIndex(where: { $0.id == noteID }) else { return false }
         guard !notes[idx].labelIDs.contains(labelID) else { return true }
+        let before = MutationAuditSnapshots.note(notes[idx])
         notes[idx].labelIDs.append(labelID)
         if var entry = index[noteID] {
             entry.labelIDs = notes[idx].labelIDs
@@ -975,12 +976,22 @@ final class NotesStorage: ObservableObject {
         }
         saveIndex()
         persistNoteToDatabase(notes[idx])
+        MutationAuditService.shared.record(
+            action: "assign_label",
+            itemType: "note",
+            itemID: noteID,
+            before: before,
+            after: MutationAuditSnapshots.note(notes[idx]),
+            metadata: ["labelID": labelID.uuidString]
+        )
         return true
     }
 
     @discardableResult
     func removeLabel(_ noteID: UUID, labelID: UUID) -> Bool {
         guard let idx = notes.firstIndex(where: { $0.id == noteID }) else { return false }
+        guard notes[idx].labelIDs.contains(labelID) else { return true }
+        let before = MutationAuditSnapshots.note(notes[idx])
         notes[idx].labelIDs.removeAll { $0 == labelID }
         if var entry = index[noteID] {
             entry.labelIDs = notes[idx].labelIDs
@@ -988,6 +999,14 @@ final class NotesStorage: ObservableObject {
         }
         saveIndex()
         persistNoteToDatabase(notes[idx])
+        MutationAuditService.shared.record(
+            action: "remove_label",
+            itemType: "note",
+            itemID: noteID,
+            before: before,
+            after: MutationAuditSnapshots.note(notes[idx]),
+            metadata: ["labelID": labelID.uuidString]
+        )
         return true
     }
 

--- a/Sources/Cider/Services/TodoCardStorage.swift
+++ b/Sources/Cider/Services/TodoCardStorage.swift
@@ -229,6 +229,12 @@ final class TodoCardStorage: ObservableObject {
         todoCards.append(todoCard)
         sortCards()
         persistTodoToDatabase(todoCard)
+        MutationAuditService.shared.record(
+            action: "create",
+            itemType: "todo",
+            itemID: todoCard.id,
+            after: MutationAuditSnapshots.todo(todoCard)
+        )
         return todoCard
     }
 
@@ -258,6 +264,8 @@ final class TodoCardStorage: ObservableObject {
     @discardableResult
     func updateTodoCard(_ updated: TodoCard) -> Bool {
         guard let idx = todoCards.firstIndex(where: { $0.id == updated.id }) else { return false }
+        let beforeCard = todoCards[idx]
+        let before = MutationAuditSnapshots.todo(beforeCard)
         var copy = updated
         copy.updatedAt = Date()
 
@@ -294,12 +302,22 @@ final class TodoCardStorage: ObservableObject {
         saveIndex()
         sortCards()
         persistTodoToDatabase(copy)
+        if beforeCard.title != copy.title {
+            MutationAuditService.shared.record(
+                action: "rename",
+                itemType: "todo",
+                itemID: copy.id,
+                before: before,
+                after: MutationAuditSnapshots.todo(copy)
+            )
+        }
         return true
     }
 
     @discardableResult
     func deleteTodoCard(_ id: UUID) -> TrashItem? {
         guard let todoCard = todoCards.first(where: { $0.id == id }) else { return nil }
+        let before = MutationAuditSnapshots.todo(todoCard)
 
         let icsFileURL = resolveFileURL(for: id)
         let trashItem = TrashStorage.shared.trashTodoCard(
@@ -312,6 +330,13 @@ final class TodoCardStorage: ObservableObject {
         index.removeValue(forKey: id)
         saveIndex()
         deleteTodoFromDatabase(id)
+        MutationAuditService.shared.record(
+            action: "delete",
+            itemType: "todo",
+            itemID: id,
+            before: before,
+            after: MutationAuditSnapshots.trashItem(trashItem)
+        )
         return trashItem
     }
 
@@ -372,6 +397,7 @@ final class TodoCardStorage: ObservableObject {
         guard todoCards[idx].folderID != folderID else { return true }
 
         let todoCard = todoCards[idx]
+        let before = MutationAuditSnapshots.todo(todoCard)
         guard let entry = index[id] else { return false }
 
         let oldDirURL = resolveDirectoryURL(folderID: todoCard.folderID)
@@ -400,6 +426,13 @@ final class TodoCardStorage: ObservableObject {
         index[id] = updatedEntry
         saveIndex()
         persistTodoToDatabase(todoCards[idx])
+        MutationAuditService.shared.record(
+            action: "reassign_folder",
+            itemType: "todo",
+            itemID: id,
+            before: before,
+            after: MutationAuditSnapshots.todo(todoCards[idx])
+        )
         return true
     }
 
@@ -497,6 +530,20 @@ final class TodoCardStorage: ObservableObject {
         todoCards.append(todoCard)
         sortCards()
         persistTodoToDatabase(todoCard)
+        MutationAuditService.shared.record(
+            action: "restore",
+            itemType: "todo",
+            itemID: todoCard.id,
+            before: MutationAuditSnapshots.trashItem(
+                TrashItem(
+                    itemID: todoCard.id,
+                    itemType: .todo,
+                    title: todoCard.title,
+                    originalFolderID: todoCard.folderID
+                )
+            ),
+            after: MutationAuditSnapshots.todo(todoCard)
+        )
     }
 
     // MARK: - File I/O

--- a/Sources/Cider/Services/TrashStorage.swift
+++ b/Sources/Cider/Services/TrashStorage.swift
@@ -45,6 +45,10 @@ final class TrashStorage {
         database ?? (CiderDatabase.shared.isOpen ? CiderDatabase.shared : nil)
     }
 
+    private var resolvedAuditService: MutationAuditService {
+        MutationAuditService(database: resolvedDatabase)
+    }
+
     private init() {}
 
     /// Testing-only initializer with an explicit database.
@@ -591,6 +595,7 @@ final class TrashStorage {
         let trashDir = vaultFilesTrashDir
         let fm = FileManager.default
         try? fm.createDirectory(at: trashDir, withIntermediateDirectories: true)
+        let before = MutationAuditSnapshots.vaultFile(file)
 
         var trashFilename: String?
         if fm.fileExists(atPath: file.absoluteURL.path) {
@@ -611,6 +616,13 @@ final class TrashStorage {
         addToManifest(trashItem, trashDir: trashDir)
         VaultFileStorage.shared.removeMetadata(for: file.id)
         VaultFileService.shared.scan()
+        resolvedAuditService.record(
+            action: "delete",
+            itemType: "vaultFile",
+            itemID: file.id,
+            before: before,
+            after: MutationAuditSnapshots.trashItem(trashItem)
+        )
         return trashItem
     }
 
@@ -689,6 +701,13 @@ final class TrashStorage {
         removeFromManifest(trashItem.id, trashDir: trashDir)
         VaultFileStorage.shared.restoreMetadata(from: payload.vaultFile)
         VaultFileService.shared.scan()
+        resolvedAuditService.record(
+            action: "restore",
+            itemType: "vaultFile",
+            itemID: payload.vaultFile.id,
+            before: MutationAuditSnapshots.trashItem(trashItem),
+            after: MutationAuditSnapshots.vaultFile(payload.vaultFile)
+        )
     }
 
     // MARK: - Generic Restore
@@ -752,6 +771,14 @@ final class TrashStorage {
             }
         }
 
+        for item in expired {
+            recordTrashRemoval(
+                action: "purge_expired",
+                trashItem: item,
+                metadata: ["cutoff": String(cutoff.timeIntervalSince1970)]
+            )
+        }
+
         NotificationCenter.default.post(name: .trashContentsChanged, object: nil)
     }
 
@@ -782,6 +809,14 @@ final class TrashStorage {
             }
         }
 
+        for item in expired {
+            recordTrashRemoval(
+                action: "purge_expired",
+                trashItem: item,
+                metadata: ["cutoff": String(cutoff.timeIntervalSince1970)]
+            )
+        }
+
         NotificationCenter.default.post(name: .trashContentsChanged, object: nil)
     }
 
@@ -793,10 +828,12 @@ final class TrashStorage {
             let trashDir = resolveTrashDir(for: trashItem)
             deleteFilesForItem(trashItem, trashDir: trashDir)
             removeFromManifest(trashItem.id, trashDir: trashDir)
+            recordTrashRemoval(action: "permanently_delete", trashItem: trashItem)
         case .note:
             let trashDir = resolveTrashDir(for: trashItem)
             deleteFilesForItem(trashItem, trashDir: trashDir)
             removeFromManifest(trashItem.id, trashDir: trashDir)
+            recordTrashRemoval(action: "permanently_delete", trashItem: trashItem)
         case .folder:
             for content in trashItem.folderContents ?? [] {
                 permanentlyDelete(content)
@@ -805,10 +842,12 @@ final class TrashStorage {
             let trashDir = StoragePaths.directoryURL(for: .dateCards).appendingPathComponent(trashDirName)
             deleteFilesForItem(trashItem, trashDir: trashDir)
             removeFromManifest(trashItem.id, trashDir: trashDir)
+            recordTrashRemoval(action: "permanently_delete", trashItem: trashItem)
         case .todo:
             let trashDir = StoragePaths.directoryURL(for: .todos).appendingPathComponent(trashDirName)
             deleteFilesForItem(trashItem, trashDir: trashDir)
             removeFromManifest(trashItem.id, trashDir: trashDir)
+            recordTrashRemoval(action: "permanently_delete", trashItem: trashItem)
         case .contact:
             let trashDir = StoragePaths.directoryURL(for: .contacts).appendingPathComponent(trashDirName)
             deleteFilesForItem(trashItem, trashDir: trashDir)
@@ -822,6 +861,7 @@ final class TrashStorage {
                 }
             }
             removeFromManifest(trashItem.id, trashDir: trashDir)
+            recordTrashRemoval(action: "permanently_delete", trashItem: trashItem)
         case .vaultFolder:
             // Vault folder trash is managed by VaultFolderService
             if let payload = trashItem.vaultFolderPayload {
@@ -830,17 +870,20 @@ final class TrashStorage {
                 let trashFolderURL = trashDir.appendingPathComponent(payload.folder.id.uuidString)
                 try? FileManager.default.removeItem(at: trashFolderURL)
                 removeFromManifest(trashItem.id, trashDir: trashDir)
+                recordTrashRemoval(action: "permanently_delete", trashItem: trashItem)
             }
         case .session:
             break // Sessions feature removed
         case .kanbanBoard:
             let trashDir = StoragePaths.directoryURL(for: .kanbanBoards).appendingPathComponent(trashDirName)
             removeFromManifest(trashItem.id, trashDir: trashDir)
+            recordTrashRemoval(action: "permanently_delete", trashItem: trashItem)
         case .vaultFile:
             if let payload = trashItem.vaultFilePayload, let trashFilename = payload.trashFilename {
                 try? FileManager.default.removeItem(at: vaultFilesTrashDir.appendingPathComponent(trashFilename))
             }
             removeFromManifest(trashItem.id, trashDir: vaultFilesTrashDir)
+            recordTrashRemoval(action: "permanently_delete", trashItem: trashItem)
         }
     }
 
@@ -858,6 +901,10 @@ final class TrashStorage {
         deleteAllTrashItemsFromDatabase()
         // Clear any pending undo action that references trashed items — prevents ghost restores
         CiderUndoManager.shared.discard()
+
+        for item in items {
+            recordTrashRemoval(action: "empty_trash_delete", trashItem: item)
+        }
     }
 
     // MARK: - Private Helpers
@@ -970,6 +1017,23 @@ final class TrashStorage {
                 try? fm.removeItem(at: trashDir.appendingPathComponent(trashFilename))
             }
         }
+    }
+
+    private func recordTrashRemoval(
+        action: String,
+        trashItem: TrashItem,
+        metadata: [String: String] = [:]
+    ) {
+        var finalMetadata = metadata
+        finalMetadata["trashItemID"] = trashItem.id.uuidString
+        resolvedAuditService.record(
+            action: action,
+            itemType: trashItem.itemType.rawValue,
+            itemID: trashItem.itemID,
+            before: MutationAuditSnapshots.trashItem(trashItem),
+            after: ["state": "removed_from_trash"],
+            metadata: finalMetadata
+        )
     }
 
     // Task 13: Per-directory JSON trash manifests removed. SQLite `trash` table

--- a/Sources/Cider/Services/TrashStorage.swift
+++ b/Sources/Cider/Services/TrashStorage.swift
@@ -750,36 +750,38 @@ final class TrashStorage {
 
     func purgeExpired(olderThan days: Int) {
         guard days > 0 else { return }
-        let cutoff = Date().addingTimeInterval(-Double(days) * 24 * 3600)
-        let expired = allTrashItems().filter { $0.deletedAt < cutoff }
-        guard !expired.isEmpty else { return }
+        MutationAuditContext.withSource(.cleanup) {
+            let cutoff = Date().addingTimeInterval(-Double(days) * 24 * 3600)
+            let expired = allTrashItems().filter { $0.deletedAt < cutoff }
+            guard !expired.isEmpty else { return }
 
-        for item in expired {
-            let trashDir = resolveTrashDir(for: item)
-            deleteFilesForItem(item, trashDir: trashDir)
-        }
-
-        if let db = resolvedDatabase {
-            do {
-                try db.withTransaction {
-                    for item in expired {
-                        deleteTrashItemFromDatabase(db, trashItemID: item.id)
-                    }
-                }
-            } catch {
-                Self.logger.error("purgeExpired: SQLite batch delete failed: \(error.localizedDescription)")
+            for item in expired {
+                let trashDir = resolveTrashDir(for: item)
+                deleteFilesForItem(item, trashDir: trashDir)
             }
-        }
 
-        for item in expired {
-            recordTrashRemoval(
-                action: "purge_expired",
-                trashItem: item,
-                metadata: ["cutoff": String(cutoff.timeIntervalSince1970)]
-            )
-        }
+            if let db = resolvedDatabase {
+                do {
+                    try db.withTransaction {
+                        for item in expired {
+                            deleteTrashItemFromDatabase(db, trashItemID: item.id)
+                        }
+                    }
+                } catch {
+                    Self.logger.error("purgeExpired: SQLite batch delete failed: \(error.localizedDescription)")
+                }
+            }
 
-        NotificationCenter.default.post(name: .trashContentsChanged, object: nil)
+            for item in expired {
+                recordTrashRemoval(
+                    action: "purge_expired",
+                    trashItem: item,
+                    metadata: ["cutoff": String(cutoff.timeIntervalSince1970)]
+                )
+            }
+
+            NotificationCenter.default.post(name: .trashContentsChanged, object: nil)
+        }
     }
 
     // Internal for testing
@@ -788,36 +790,38 @@ final class TrashStorage {
     /// compatibility but is no longer used to scope the purge — SQLite is the
     /// source of truth.
     func purgeExpired(olderThan cutoff: Date, in trashDir: URL) {
-        let all = allTrashItems()
-        let expired = all.filter { $0.deletedAt < cutoff }
-        guard !expired.isEmpty else { return }
+        MutationAuditContext.withSource(.cleanup) {
+            let all = allTrashItems()
+            let expired = all.filter { $0.deletedAt < cutoff }
+            guard !expired.isEmpty else { return }
 
-        for item in expired {
-            let dir = resolveTrashDir(for: item)
-            deleteFilesForItem(item, trashDir: dir)
-        }
-
-        if let db = resolvedDatabase {
-            do {
-                try db.withTransaction {
-                    for item in expired {
-                        deleteTrashItemFromDatabase(db, trashItemID: item.id)
-                    }
-                }
-            } catch {
-                Self.logger.error("purgeExpired: SQLite batch delete failed: \(error.localizedDescription)")
+            for item in expired {
+                let dir = resolveTrashDir(for: item)
+                deleteFilesForItem(item, trashDir: dir)
             }
-        }
 
-        for item in expired {
-            recordTrashRemoval(
-                action: "purge_expired",
-                trashItem: item,
-                metadata: ["cutoff": String(cutoff.timeIntervalSince1970)]
-            )
-        }
+            if let db = resolvedDatabase {
+                do {
+                    try db.withTransaction {
+                        for item in expired {
+                            deleteTrashItemFromDatabase(db, trashItemID: item.id)
+                        }
+                    }
+                } catch {
+                    Self.logger.error("purgeExpired: SQLite batch delete failed: \(error.localizedDescription)")
+                }
+            }
 
-        NotificationCenter.default.post(name: .trashContentsChanged, object: nil)
+            for item in expired {
+                recordTrashRemoval(
+                    action: "purge_expired",
+                    trashItem: item,
+                    metadata: ["cutoff": String(cutoff.timeIntervalSince1970)]
+                )
+            }
+
+            NotificationCenter.default.post(name: .trashContentsChanged, object: nil)
+        }
     }
 
     // MARK: - Permanent Delete

--- a/Sources/Cider/Services/VaultBookmarkService.swift
+++ b/Sources/Cider/Services/VaultBookmarkService.swift
@@ -634,6 +634,12 @@ final class VaultBookmarkService: ObservableObject {
 
         bookmarks.insert(bookmark, at: 0)
         persist()
+        MutationAuditService.shared.record(
+            action: "create",
+            itemType: "bookmark",
+            itemID: bookmark.id,
+            after: MutationAuditSnapshots.bookmark(bookmark)
+        )
         startEnrichmentIfNeeded(for: bookmark.id)
         return bookmark
     }
@@ -657,6 +663,12 @@ final class VaultBookmarkService: ObservableObject {
 
         bookmarks.insert(bookmark, at: 0)
         persist()
+        MutationAuditService.shared.record(
+            action: "create",
+            itemType: "bookmark",
+            itemID: bookmark.id,
+            after: MutationAuditSnapshots.bookmark(bookmark)
+        )
         return bookmark
     }
 
@@ -681,6 +693,7 @@ final class VaultBookmarkService: ObservableObject {
 
     @discardableResult
     func remove(_ bookmark: Bookmark) -> TrashItem {
+        let before = MutationAuditSnapshots.bookmark(bookmark)
         cancelEnrichment(for: bookmark.id)
         SyncService.shared.trackDeletion(of: bookmark.id)
         // Track deleted URL so adoption doesn't re-adopt duplicate files
@@ -693,12 +706,20 @@ final class VaultBookmarkService: ObservableObject {
         bookmarks.removeAll { $0.id == bookmark.id }
         deleteBookmarkFromDatabase(bookmark.id)
         persist()
+        MutationAuditService.shared.record(
+            action: "delete",
+            itemType: "bookmark",
+            itemID: bookmark.id,
+            before: before,
+            after: MutationAuditSnapshots.trashItem(trashItem)
+        )
         return trashItem
     }
 
     @discardableResult
     func removeAll(_ bookmarksToDelete: [Bookmark]) -> [TrashItem] {
         var trashItems: [TrashItem] = []
+        var deletedPairs: [(Bookmark, TrashItem)] = []
         for bookmark in bookmarksToDelete {
             cancelEnrichment(for: bookmark.id)
             SyncService.shared.trackDeletion(of: bookmark.id)
@@ -709,6 +730,7 @@ final class VaultBookmarkService: ObservableObject {
             let item = TrashStorage.shared.trashBookmark(bookmark, bookmarksDir: bookmarkDir, bookmarksMetaDir: bookmarksMetaDir)
             deleteWeblocFileOnly(for: bookmark)
             trashItems.append(item)
+            deletedPairs.append((bookmark, item))
         }
         let ids = Set(bookmarksToDelete.map(\.id))
         bookmarks.removeAll { ids.contains($0.id) }
@@ -716,6 +738,15 @@ final class VaultBookmarkService: ObservableObject {
             deleteBookmarkFromDatabase(id)
         }
         persist()
+        for (bookmark, trashItem) in deletedPairs {
+            MutationAuditService.shared.record(
+                action: "delete",
+                itemType: "bookmark",
+                itemID: bookmark.id,
+                before: MutationAuditSnapshots.bookmark(bookmark),
+                after: MutationAuditSnapshots.trashItem(trashItem)
+            )
+        }
         return trashItems
     }
 
@@ -763,6 +794,20 @@ final class VaultBookmarkService: ObservableObject {
 
         bookmarks.insert(restored, at: 0)
         persist()
+        MutationAuditService.shared.record(
+            action: "restore",
+            itemType: "bookmark",
+            itemID: restored.id,
+            before: MutationAuditSnapshots.trashItem(
+                TrashItem(
+                    itemID: restored.id,
+                    itemType: .bookmark,
+                    title: restored.title,
+                    originalFolderID: restored.folderID
+                )
+            ),
+            after: MutationAuditSnapshots.bookmark(restored)
+        )
     }
 
     // MARK: - Update Details
@@ -779,6 +824,8 @@ final class VaultBookmarkService: ObservableObject {
         guard let index = bookmarks.firstIndex(where: { $0.id == bookmarkID }) else { return false }
 
         var bookmark = bookmarks[index]
+        let before = MutationAuditSnapshots.bookmark(bookmark)
+        let oldTitle = bookmark.title
         let resolvedURL = URL(string: bookmark.urlString)
         let normalizedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedTitleValue: String
@@ -815,6 +862,15 @@ final class VaultBookmarkService: ObservableObject {
             bookmark.updatedAt = Date()
             bookmarks[index] = bookmark
             persist()
+            if oldTitle != bookmark.title {
+                MutationAuditService.shared.record(
+                    action: "rename",
+                    itemType: "bookmark",
+                    itemID: bookmarkID,
+                    before: before,
+                    after: MutationAuditSnapshots.bookmark(bookmark)
+                )
+            }
         }
 
         return true
@@ -865,6 +921,7 @@ final class VaultBookmarkService: ObservableObject {
         }
 
         let bookmark = bookmarks[index]
+        let before = MutationAuditSnapshots.bookmark(bookmark)
 
         // PHYSICALLY MOVE the .webloc file
         if let relativePath = bookmark.relativePath, !relativePath.isEmpty {
@@ -893,6 +950,13 @@ final class VaultBookmarkService: ObservableObject {
         bookmarks[index].folderID = folderID
         bookmarks[index].updatedAt = Date()
         persist()
+        MutationAuditService.shared.record(
+            action: "reassign_folder",
+            itemType: "bookmark",
+            itemID: bookmarkID,
+            before: before,
+            after: MutationAuditSnapshots.bookmark(bookmarks[index])
+        )
         return true
     }
 
@@ -1030,21 +1094,42 @@ final class VaultBookmarkService: ObservableObject {
     }
 
     func removeSynced(_ bookmark: Bookmark) {
-        cancelEnrichment(for: bookmark.id)
-        deleteWeblocFile(for: bookmark)
-        bookmarks.removeAll { $0.id == bookmark.id }
-        deleteBookmarkFromDatabase(bookmark.id)
-        persist()
+        MutationAuditContext.withSource(.cleanup) {
+            let before = MutationAuditSnapshots.bookmark(bookmark)
+            cancelEnrichment(for: bookmark.id)
+            deleteWeblocFile(for: bookmark)
+            bookmarks.removeAll { $0.id == bookmark.id }
+            deleteBookmarkFromDatabase(bookmark.id)
+            persist()
+            MutationAuditService.shared.record(
+                action: "delete",
+                itemType: "bookmark",
+                itemID: bookmark.id,
+                before: before,
+                after: ["state": "removed_by_sync"],
+                metadata: ["reason": "sync_remove"]
+            )
+        }
     }
 
     func trashFromSync(_ bookmark: Bookmark) {
-        cancelEnrichment(for: bookmark.id)
-        let (bookmarkDir, _) = resolveBookmarkDirectory(bookmark.folderID)
-        _ = TrashStorage.shared.trashBookmark(bookmark, bookmarksDir: bookmarkDir, bookmarksMetaDir: bookmarksMetaDir)
-        deleteWeblocFile(for: bookmark)
-        bookmarks.removeAll { $0.id == bookmark.id }
-        deleteBookmarkFromDatabase(bookmark.id)
-        persist()
+        MutationAuditContext.withSource(.cleanup) {
+            cancelEnrichment(for: bookmark.id)
+            let (bookmarkDir, _) = resolveBookmarkDirectory(bookmark.folderID)
+            let trashItem = TrashStorage.shared.trashBookmark(bookmark, bookmarksDir: bookmarkDir, bookmarksMetaDir: bookmarksMetaDir)
+            deleteWeblocFile(for: bookmark)
+            bookmarks.removeAll { $0.id == bookmark.id }
+            deleteBookmarkFromDatabase(bookmark.id)
+            persist()
+            MutationAuditService.shared.record(
+                action: "delete",
+                itemType: "bookmark",
+                itemID: bookmark.id,
+                before: MutationAuditSnapshots.bookmark(bookmark),
+                after: MutationAuditSnapshots.trashItem(trashItem),
+                metadata: ["reason": "sync_trash"]
+            )
+        }
     }
 
     // MARK: - Import/Export

--- a/Sources/Cider/Services/VaultBookmarkService.swift
+++ b/Sources/Cider/Services/VaultBookmarkService.swift
@@ -966,19 +966,38 @@ final class VaultBookmarkService: ObservableObject {
     func assignLabel(_ bookmarkID: UUID, labelID: UUID) -> Bool {
         guard let idx = bookmarks.firstIndex(where: { $0.id == bookmarkID }) else { return false }
         guard !bookmarks[idx].labelIDs.contains(labelID) else { return true }
+        let before = MutationAuditSnapshots.bookmark(bookmarks[idx])
         bookmarks[idx].labelIDs.append(labelID)
         persist()
+        MutationAuditService.shared.record(
+            action: "assign_label",
+            itemType: "bookmark",
+            itemID: bookmarkID,
+            before: before,
+            after: MutationAuditSnapshots.bookmark(bookmarks[idx]),
+            metadata: ["labelID": labelID.uuidString]
+        )
         return true
     }
 
     @discardableResult
     func removeLabel(_ bookmarkID: UUID, labelID: UUID) -> Bool {
         guard let idx = bookmarks.firstIndex(where: { $0.id == bookmarkID }) else { return false }
+        guard bookmarks[idx].labelIDs.contains(labelID) else { return true }
+        let before = MutationAuditSnapshots.bookmark(bookmarks[idx])
         bookmarks[idx].labelIDs.removeAll { $0 == labelID }
         if !bookmarks[idx].dismissedLabelIDs.contains(labelID) {
             bookmarks[idx].dismissedLabelIDs.append(labelID)
         }
         persist()
+        MutationAuditService.shared.record(
+            action: "remove_label",
+            itemType: "bookmark",
+            itemID: bookmarkID,
+            before: before,
+            after: MutationAuditSnapshots.bookmark(bookmarks[idx]),
+            metadata: ["labelID": labelID.uuidString]
+        )
         return true
     }
 

--- a/Sources/Cider/Services/VaultFolderService.swift
+++ b/Sources/Cider/Services/VaultFolderService.swift
@@ -124,6 +124,12 @@ final class VaultFolderService {
 
         logger.info("Created folder '\(resolvedName)' at \(relativePath)")
         NotificationCenter.default.post(name: .vaultFoldersChanged, object: nil)
+        MutationAuditService.shared.record(
+            action: "create",
+            itemType: "vaultFolder",
+            itemID: folder.id,
+            after: MutationAuditSnapshots.folder(folder)
+        )
         return folder
     }
 
@@ -131,6 +137,7 @@ final class VaultFolderService {
     @discardableResult
     func renameFolder(_ folderID: UUID, to name: String) -> Bool {
         guard let folder = index[folderID] else { return false }
+        let before = MutationAuditSnapshots.folder(folder)
 
         let sanitized = Self.sanitizeDirectoryName(name)
         guard !sanitized.isEmpty else { return false }
@@ -181,6 +188,15 @@ final class VaultFolderService {
 
         logger.info("Renamed folder '\(folder.name)' → '\(resolvedName)'")
         NotificationCenter.default.post(name: .vaultFoldersChanged, object: nil)
+        if let updatedFolder = index[folderID] {
+            MutationAuditService.shared.record(
+                action: "rename",
+                itemType: "vaultFolder",
+                itemID: folderID,
+                before: before,
+                after: MutationAuditSnapshots.folder(updatedFolder)
+            )
+        }
         return true
     }
 
@@ -194,6 +210,7 @@ final class VaultFolderService {
     @discardableResult
     func moveFolder(_ folderID: UUID, toParentID newParentID: UUID?) -> Bool {
         guard let folder = index[folderID] else { return false }
+        let before = MutationAuditSnapshots.folder(folder)
 
         // Resolve new parent path, with guards against moving into self / a descendant.
         let newParentPath: String?
@@ -277,6 +294,15 @@ final class VaultFolderService {
         logger.info("Moved folder '\(folder.name)' from \(oldRelativePath) → \(newRelativePath)")
         NotificationCenter.default.post(name: .vaultFoldersChanged, object: nil)
         SyncService.shared.pushAfterLocalChange()
+        if let updatedFolder = index[folderID] {
+            MutationAuditService.shared.record(
+                action: "move",
+                itemType: "vaultFolder",
+                itemID: folderID,
+                before: before,
+                after: MutationAuditSnapshots.folder(updatedFolder)
+            )
+        }
         return true
     }
 
@@ -376,6 +402,7 @@ final class VaultFolderService {
     @discardableResult
     func deleteFolder(_ folderID: UUID) -> TrashItem? {
         guard let folder = index[folderID] else { return nil }
+        let before = MutationAuditSnapshots.folder(folder)
 
         let sourceURL = vaultRoot.appendingPathComponent(folder.relativePath)
         let trashDestURL = trashDir.appendingPathComponent(folder.id.uuidString)
@@ -400,58 +427,67 @@ final class VaultFolderService {
         // 3. Drain items. Track failures — if any relocation fails,
         // we abort the folder delete entirely so we never trash a
         // directory with live content still inside.
-        var failures: [DeleteFolderFailure] = []
-
-        for id in deletedFolderIDs {
-            // Notes — assignNote returns Bool AND moves .md on disk
-            for note in NotesStorage.shared.notes where note.folderID == id {
-                let ok = NotesStorage.shared.assignNote(note.id, toFolder: nil)
-                let nowUnfiled = NotesStorage.shared.notes.first(where: { $0.id == note.id })?.folderID == nil
-                if !ok || !nowUnfiled {
-                    failures.append(.init(itemType: "note", itemID: note.id, title: note.title))
+        var relocatedItemCount = 0
+        let failures: [DeleteFolderFailure] = MutationAuditContext.withSource(.cleanup) {
+            var failures: [DeleteFolderFailure] = []
+            for id in deletedFolderIDs {
+                // Notes — assignNote returns Bool AND moves .md on disk
+                for note in NotesStorage.shared.notes where note.folderID == id {
+                    relocatedItemCount += 1
+                    let ok = NotesStorage.shared.assignNote(note.id, toFolder: nil)
+                    let nowUnfiled = NotesStorage.shared.notes.first(where: { $0.id == note.id })?.folderID == nil
+                    if !ok || !nowUnfiled {
+                        failures.append(.init(itemType: "note", itemID: note.id, title: note.title))
+                    }
+                }
+                // Bookmarks — assignBookmark returns Bool AND moves .webloc on disk
+                for bookmark in VaultBookmarkService.shared.bookmarks where bookmark.folderID == id {
+                    relocatedItemCount += 1
+                    let ok = VaultBookmarkService.shared.assignBookmark(bookmark.id, toFolder: nil)
+                    let nowUnfiled = VaultBookmarkService.shared.bookmarks.first(where: { $0.id == bookmark.id })?.folderID == nil
+                    if !ok || !nowUnfiled {
+                        failures.append(.init(itemType: "bookmark", itemID: bookmark.id, title: bookmark.title))
+                    }
+                }
+                // Vault files — assignFile is Void AND moves the file on disk;
+                // verify via post-check of the in-memory state.
+                for file in VaultFileService.shared.files where file.folderID == id {
+                    relocatedItemCount += 1
+                    VaultFileService.shared.assignFile(file.id, toFolder: nil)
+                    let nowUnfiled = VaultFileService.shared.files.first(where: { $0.id == file.id })?.folderID == nil
+                    if !nowUnfiled {
+                        failures.append(.init(itemType: "vaultFile", itemID: file.id, title: file.displayTitle))
+                    }
+                }
+                // Todos — assignTodoCard returns Bool AND moves the .ics file on disk
+                for todo in TodoCardStorage.shared.todoCards where todo.folderID == id {
+                    relocatedItemCount += 1
+                    let ok = TodoCardStorage.shared.assignTodoCard(todo.id, toFolder: nil)
+                    let nowUnfiled = TodoCardStorage.shared.todoCards.first(where: { $0.id == todo.id })?.folderID == nil
+                    if !ok || !nowUnfiled {
+                        failures.append(.init(itemType: "todo", itemID: todo.id, title: todo.title))
+                    }
+                }
+                // Date cards (events) — assignDateCard returns Bool AND moves the .ics file on disk
+                for dc in DateCardStorage.shared.dateCards where dc.folderID == id {
+                    relocatedItemCount += 1
+                    let ok = DateCardStorage.shared.assignDateCard(dc.id, toFolder: nil)
+                    let nowUnfiled = DateCardStorage.shared.dateCards.first(where: { $0.id == dc.id })?.folderID == nil
+                    if !ok || !nowUnfiled {
+                        failures.append(.init(itemType: "event", itemID: dc.id, title: dc.title))
+                    }
+                }
+                // Contacts — assignContact returns Bool AND moves the .vcf file on disk
+                for contact in ContactStorage.shared.contacts where contact.folderID == id {
+                    relocatedItemCount += 1
+                    let ok = ContactStorage.shared.assignContact(contact.id, toFolder: nil)
+                    let nowUnfiled = ContactStorage.shared.contacts.first(where: { $0.id == contact.id })?.folderID == nil
+                    if !ok || !nowUnfiled {
+                        failures.append(.init(itemType: "contact", itemID: contact.id, title: contact.displayName))
+                    }
                 }
             }
-            // Bookmarks — assignBookmark returns Bool AND moves .webloc on disk
-            for bookmark in VaultBookmarkService.shared.bookmarks where bookmark.folderID == id {
-                let ok = VaultBookmarkService.shared.assignBookmark(bookmark.id, toFolder: nil)
-                let nowUnfiled = VaultBookmarkService.shared.bookmarks.first(where: { $0.id == bookmark.id })?.folderID == nil
-                if !ok || !nowUnfiled {
-                    failures.append(.init(itemType: "bookmark", itemID: bookmark.id, title: bookmark.title))
-                }
-            }
-            // Vault files — assignFile is Void AND moves the file on disk;
-            // verify via post-check of the in-memory state.
-            for file in VaultFileService.shared.files where file.folderID == id {
-                VaultFileService.shared.assignFile(file.id, toFolder: nil)
-                let nowUnfiled = VaultFileService.shared.files.first(where: { $0.id == file.id })?.folderID == nil
-                if !nowUnfiled {
-                    failures.append(.init(itemType: "vaultFile", itemID: file.id, title: file.displayTitle))
-                }
-            }
-            // Todos — assignTodoCard returns Bool AND moves the .ics file on disk
-            for todo in TodoCardStorage.shared.todoCards where todo.folderID == id {
-                let ok = TodoCardStorage.shared.assignTodoCard(todo.id, toFolder: nil)
-                let nowUnfiled = TodoCardStorage.shared.todoCards.first(where: { $0.id == todo.id })?.folderID == nil
-                if !ok || !nowUnfiled {
-                    failures.append(.init(itemType: "todo", itemID: todo.id, title: todo.title))
-                }
-            }
-            // Date cards (events) — assignDateCard returns Bool AND moves the .ics file on disk
-            for dc in DateCardStorage.shared.dateCards where dc.folderID == id {
-                let ok = DateCardStorage.shared.assignDateCard(dc.id, toFolder: nil)
-                let nowUnfiled = DateCardStorage.shared.dateCards.first(where: { $0.id == dc.id })?.folderID == nil
-                if !ok || !nowUnfiled {
-                    failures.append(.init(itemType: "event", itemID: dc.id, title: dc.title))
-                }
-            }
-            // Contacts — assignContact returns Bool AND moves the .vcf file on disk
-            for contact in ContactStorage.shared.contacts where contact.folderID == id {
-                let ok = ContactStorage.shared.assignContact(contact.id, toFolder: nil)
-                let nowUnfiled = ContactStorage.shared.contacts.first(where: { $0.id == contact.id })?.folderID == nil
-                if !ok || !nowUnfiled {
-                    failures.append(.init(itemType: "contact", itemID: contact.id, title: contact.displayName))
-                }
-            }
+            return failures
         }
 
         // 4. Abort on any failure — do NOT trash the folder, do NOT delete
@@ -520,6 +556,17 @@ final class VaultFolderService {
 
         logger.info("Trashed folder '\(folder.name)' and \(deletedFolders.count - 1) subfolder(s)")
         NotificationCenter.default.post(name: .vaultFoldersChanged, object: nil)
+        MutationAuditService.shared.record(
+            action: "delete",
+            itemType: "vaultFolder",
+            itemID: folder.id,
+            before: before,
+            after: MutationAuditSnapshots.trashItem(trashItem),
+            metadata: [
+                "descendantCount": String(max(0, deletedFolders.count - 1)),
+                "relocatedItemCount": String(relocatedItemCount),
+            ]
+        )
         return trashItem
     }
 
@@ -672,6 +719,13 @@ final class VaultFolderService {
 
         logger.info("Restored folder '\(folder.name)'")
         NotificationCenter.default.post(name: .vaultFoldersChanged, object: nil)
+        MutationAuditService.shared.record(
+            action: "restore",
+            itemType: "vaultFolder",
+            itemID: folder.id,
+            before: MutationAuditSnapshots.trashItem(trashItem),
+            after: MutationAuditSnapshots.folder(restoredFolder)
+        )
     }
 
     // MARK: - Metadata
@@ -943,6 +997,7 @@ final class VaultFolderService {
     /// (sync deletions are not recoverable via local trash).
     func deleteFolderFromSync(_ folderID: UUID) {
         guard let folder = index[folderID] else { return }
+        let before = MutationAuditSnapshots.folder(folder)
 
         let directoryURL = vaultRoot.appendingPathComponent(folder.relativePath)
 
@@ -959,24 +1014,33 @@ final class VaultFolderService {
             }
             return ids
         }()
-        for id in deletedIDs {
-            for note in NotesStorage.shared.notes where note.folderID == id {
-                NotesStorage.shared.assignNote(note.id, toFolder: nil)
-            }
-            for bookmark in VaultBookmarkService.shared.bookmarks where bookmark.folderID == id {
-                VaultBookmarkService.shared.assignBookmark(bookmark.id, toFolder: nil)
-            }
-            for todo in TodoCardStorage.shared.todoCards where todo.folderID == id {
-                TodoCardStorage.shared.assignTodoCard(todo.id, toFolder: nil)
-            }
-            for dc in DateCardStorage.shared.dateCards where dc.folderID == id {
-                DateCardStorage.shared.assignDateCard(dc.id, toFolder: nil)
-            }
-            for contact in ContactStorage.shared.contacts where contact.folderID == id {
-                ContactStorage.shared.assignContact(contact.id, toFolder: nil)
-            }
-            for file in VaultFileService.shared.files where file.folderID == id {
-                VaultFileService.shared.assignFile(file.id, toFolder: nil)
+        var relocatedItemCount = 0
+        MutationAuditContext.withSource(.cleanup) {
+            for id in deletedIDs {
+                for note in NotesStorage.shared.notes where note.folderID == id {
+                    relocatedItemCount += 1
+                    NotesStorage.shared.assignNote(note.id, toFolder: nil)
+                }
+                for bookmark in VaultBookmarkService.shared.bookmarks where bookmark.folderID == id {
+                    relocatedItemCount += 1
+                    VaultBookmarkService.shared.assignBookmark(bookmark.id, toFolder: nil)
+                }
+                for todo in TodoCardStorage.shared.todoCards where todo.folderID == id {
+                    relocatedItemCount += 1
+                    TodoCardStorage.shared.assignTodoCard(todo.id, toFolder: nil)
+                }
+                for dc in DateCardStorage.shared.dateCards where dc.folderID == id {
+                    relocatedItemCount += 1
+                    DateCardStorage.shared.assignDateCard(dc.id, toFolder: nil)
+                }
+                for contact in ContactStorage.shared.contacts where contact.folderID == id {
+                    relocatedItemCount += 1
+                    ContactStorage.shared.assignContact(contact.id, toFolder: nil)
+                }
+                for file in VaultFileService.shared.files where file.folderID == id {
+                    relocatedItemCount += 1
+                    VaultFileService.shared.assignFile(file.id, toFolder: nil)
+                }
             }
         }
 
@@ -1004,6 +1068,20 @@ final class VaultFolderService {
 
         logger.info("Sync: deleted folder '\(folder.name)'")
         NotificationCenter.default.post(name: .vaultFoldersChanged, object: nil)
+        MutationAuditContext.withSource(.cleanup) {
+            MutationAuditService.shared.record(
+                action: "delete",
+                itemType: "vaultFolder",
+                itemID: folderID,
+                before: before,
+                after: ["state": "removed_by_sync"],
+                metadata: [
+                    "reason": "sync_delete",
+                    "descendantCount": String(descendantIDs.count),
+                    "relocatedItemCount": String(relocatedItemCount),
+                ]
+            )
+        }
     }
 
     // MARK: - FSEvents

--- a/Sources/CiderCLI/CiderCLI.swift
+++ b/Sources/CiderCLI/CiderCLI.swift
@@ -3320,6 +3320,59 @@ struct CiderCLI {
                 print("Error running SQLite integrity check: \(error.localizedDescription)")
             }
 
+        case "audit", "log":
+            let limit = parseFlag("--limit", from: args).flatMap(Int.init) ?? 50
+            let itemTypeFilter = parseFlag("--type", from: args)?.lowercased()
+            let actionFilter = parseFlag("--action", from: args)?.lowercased()
+            let sourceFilter = parseFlag("--source", from: args)?.lowercased()
+            let itemPrefixFilter = parseFlag("--item", from: args)?.lowercased()
+
+            let auditService = MutationAuditService.shared
+            let sourceSet = Set(MutationAuditSource.allCases.map(\.rawValue))
+            if let sourceFilter, !sourceSet.contains(sourceFilter) {
+                print("Error: Unknown source '\(sourceFilter)'. Valid sources: \(MutationAuditSource.allCases.map(\.rawValue).joined(separator: ", "))")
+                return
+            }
+
+            let entries = auditService.loadEntries().filter { entry in
+                if let itemTypeFilter, entry.itemType.lowercased() != itemTypeFilter {
+                    return false
+                }
+                if let actionFilter, entry.action.lowercased() != actionFilter {
+                    return false
+                }
+                if let sourceFilter, entry.source.rawValue != sourceFilter {
+                    return false
+                }
+                if let itemPrefixFilter, !entry.itemID.uuidString.lowercased().hasPrefix(itemPrefixFilter) {
+                    return false
+                }
+                return true
+            }
+
+            let limitedEntries = limit > 0 ? Array(entries.prefix(limit)) : entries
+            if jsonOutput {
+                outputJSON(limitedEntries.map(mutationAuditEntryToDict))
+            } else if limitedEntries.isEmpty {
+                print("No mutation audit entries found.")
+            } else {
+                print("Mutation audit entries (\(limitedEntries.count)\(entries.count > limitedEntries.count ? " of \(entries.count)" : "")):")
+                for entry in limitedEntries {
+                    let timestamp = entry.occurredAt.formatted(date: .abbreviated, time: .standard)
+                    let itemID = String(entry.itemID.uuidString.prefix(8))
+                    print("  [\(timestamp)] \(entry.source.rawValue) \(entry.action) \(entry.itemType) \(itemID)")
+                    if !entry.beforeState.isEmpty {
+                        print("    before: \(formatAuditState(entry.beforeState))")
+                    }
+                    if !entry.afterState.isEmpty {
+                        print("    after:  \(formatAuditState(entry.afterState))")
+                    }
+                    if !entry.metadata.isEmpty {
+                        print("    meta:   \(formatAuditState(entry.metadata))")
+                    }
+                }
+            }
+
         case "restore":
             guard let selector = args.first else {
                 print("Error: Usage: cider-cli db restore <index|filename|latest> [--yes]")
@@ -3379,7 +3432,7 @@ struct CiderCLI {
             }
 
         default:
-            print("Commands: backups, backup, integrity, restore")
+            print("Commands: backups, backup, integrity, audit, restore")
         }
     }
 
@@ -3877,6 +3930,24 @@ struct CiderCLI {
             "createdAt": backup.createdAt.timeIntervalSince1970,
             "byteSize": backup.byteSize,
         ]
+    }
+
+    static func mutationAuditEntryToDict(_ entry: MutationAuditEntry) -> [String: Any] {
+        [
+            "id": entry.id.uuidString,
+            "occurredAt": entry.occurredAt.timeIntervalSince1970,
+            "itemType": entry.itemType,
+            "itemID": entry.itemID.uuidString,
+            "action": entry.action,
+            "source": entry.source.rawValue,
+            "before": entry.beforeState,
+            "after": entry.afterState,
+            "metadata": entry.metadata,
+        ]
+    }
+
+    static func formatAuditState(_ state: [String: String]) -> String {
+        state.keys.sorted().map { "\($0)=\(state[$0] ?? "")" }.joined(separator: ", ")
     }
 
     static func isCiderAppRunning() -> Bool {
@@ -4491,6 +4562,7 @@ struct CiderCLI {
           cider-cli db backups
           cider-cli db backup
           cider-cli db integrity
+          cider-cli db audit [--limit <n>] [--type <item-type>] [--action <action>] [--source <ui|cli|agent|migration|cleanup>] [--item <id-prefix>]
           cider-cli db restore <index|filename|latest> --yes
 
         QUERY (natural language search)

--- a/Tests/CiderTests/CiderDatabaseTests.swift
+++ b/Tests/CiderTests/CiderDatabaseTests.swift
@@ -70,7 +70,7 @@ struct CiderDatabaseTests {
             "folders", "labels", "items", "bookmarks", "notes", "todos",
             "events", "contacts", "vault_files", "sessions",
             "item_labels", "dismissed_labels", "tags", "item_tags",
-            "item_links", "trash", "schema_version", "schema_migrations",
+            "item_links", "trash", "mutation_audit", "schema_version", "schema_migrations",
         ]
 
         for table in expectedTables {

--- a/Tests/CiderTests/MutationAuditServiceTests.swift
+++ b/Tests/CiderTests/MutationAuditServiceTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import Cider
+
+@Suite("Mutation Audit Tests")
+@MainActor
+struct MutationAuditServiceTests {
+
+    private func makeTempDBURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+        let filename = "cider-audit-test-\(UUID().uuidString).db"
+        return dir.appendingPathComponent(filename)
+    }
+
+    private func cleanup(_ url: URL) {
+        let fm = FileManager.default
+        try? fm.removeItem(at: url)
+        let path = url.path
+        try? fm.removeItem(atPath: path + "-wal")
+        try? fm.removeItem(atPath: path + "-shm")
+    }
+
+    private func makeTestDB() throws -> (CiderDatabase, URL) {
+        let url = makeTempDBURL()
+        let db = CiderDatabase()
+        try db.open(at: url)
+        return (db, url)
+    }
+
+    @Test("Mutation audit entries round-trip with before/after snapshots")
+    func auditEntryRoundTrip() throws {
+        let (db, url) = try makeTestDB()
+        defer { db.close(); cleanup(url) }
+
+        let service = MutationAuditService(database: db)
+        let itemID = UUID()
+
+        service.record(
+            action: "rename",
+            itemType: "note",
+            itemID: itemID,
+            before: ["title": "Old", "folderID": "inbox"],
+            after: ["title": "New", "folderID": "Projects"],
+            metadata: ["reason": "manual"]
+        )
+
+        let entries = service.loadEntries()
+        #expect(entries.count == 1)
+        #expect(entries[0].itemID == itemID)
+        #expect(entries[0].action == "rename")
+        #expect(entries[0].itemType == "note")
+        #expect(entries[0].source == .ui)
+        #expect(entries[0].beforeState["title"] == "Old")
+        #expect(entries[0].afterState["title"] == "New")
+        #expect(entries[0].metadata["reason"] == "manual")
+    }
+
+    @Test("Mutation audit context overrides source for agent writes")
+    func auditContextOverridesSource() throws {
+        let (db, url) = try makeTestDB()
+        defer { db.close(); cleanup(url) }
+
+        let service = MutationAuditService(database: db)
+        let itemID = UUID()
+
+        MutationAuditContext.withSource(.agent) {
+            service.record(
+                action: "delete",
+                itemType: "bookmark",
+                itemID: itemID,
+                before: ["title": "Example"],
+                after: ["trashItemID": UUID().uuidString]
+            )
+        }
+
+        let entries = service.loadEntries()
+        #expect(entries.count == 1)
+        #expect(entries[0].source == .agent)
+        #expect(entries[0].action == "delete")
+    }
+}

--- a/Tests/CiderTests/TrashSQLiteTests.swift
+++ b/Tests/CiderTests/TrashSQLiteTests.swift
@@ -597,6 +597,7 @@ struct TrashSQLiteTests {
         defer { db.close(); cleanup(url) }
 
         let service = makeService(db)
+        let audit = MutationAuditService(database: db)
 
         // Build a temp trash dir with a manifest containing one expired + one fresh item.
         let tmpTrashDir = FileManager.default.temporaryDirectory
@@ -631,5 +632,35 @@ struct TrashSQLiteTests {
         let remaining = service.loadTrashItemsFromDatabase(db)
         #expect(remaining.count == 1)
         #expect(remaining.first?.title == "Fresh")
+
+        let entries = audit.loadEntries()
+        #expect(entries.count == 1)
+        #expect(entries[0].action == "purge_expired")
+        #expect(entries[0].itemID == expiredItem.itemID)
+    }
+
+    @Test("permanentlyDelete removes row and records an audit entry")
+    func permanentlyDeleteRecordsAuditEntry() throws {
+        let (db, url) = try makeTestDB()
+        defer { db.close(); cleanup(url) }
+
+        let service = makeService(db)
+        let audit = MutationAuditService(database: db)
+        let item = makeBookmarkTrashItem(
+            bookmark: makeBookmark(title: "Disposable"),
+            deletedAt: Date(timeIntervalSince1970: 1_700_000_111)
+        )
+
+        service.persistTrashItemToDatabase(db, item: item)
+        #expect(service.loadTrashItemsFromDatabase(db).count == 1)
+
+        service.permanentlyDelete(item)
+
+        #expect(service.loadTrashItemsFromDatabase(db).isEmpty)
+        let entries = audit.loadEntries()
+        #expect(entries.count == 1)
+        #expect(entries[0].action == "permanently_delete")
+        #expect(entries[0].itemID == item.itemID)
+        #expect(entries[0].beforeState["trashItemID"] == item.id.uuidString)
     }
 }

--- a/Tests/CiderTests/TrashSQLiteTests.swift
+++ b/Tests/CiderTests/TrashSQLiteTests.swift
@@ -637,6 +637,7 @@ struct TrashSQLiteTests {
         #expect(entries.count == 1)
         #expect(entries[0].action == "purge_expired")
         #expect(entries[0].itemID == expiredItem.itemID)
+        #expect(entries[0].source == .cleanup)
     }
 
     @Test("permanentlyDelete removes row and records an audit entry")


### PR DESCRIPTION
## Summary
- add an append-only `mutation_audit` table, migration, and shared audit service for recording high-impact writes
- wire note, bookmark, todo, date card, contact, folder, trash, CLI, and agent mutation paths through audit logging with source tagging
- cover trash purge/permanent-delete audit behavior and audit service round-trips in focused tests

## Why
Cider could perform destructive or high-impact mutations, but it had limited ability to answer what changed, when it changed, and whether the source was the UI, CLI, agent, or cleanup/sync work. This patch makes those writes traceable before we layer on more automation.

## Impact
- destructive and high-impact mutations now leave append-only audit rows in SQLite
- agent-triggered writes are explicitly tagged as `agent`
- sync/cleanup-driven deletes are tagged as `cleanup` instead of looking like user UI actions
- trash purge, permanent delete, and empty-trash flows now leave breadcrumbs too

## Validation
- `swift test --filter "(MutationAuditServiceTests|TrashSQLiteTests|CiderDatabaseTests)"`
